### PR TITLE
fix(build): set unsafe-perm to true

### DIFF
--- a/assets/build.sh
+++ b/assets/build.sh
@@ -47,7 +47,8 @@ exec docker run \
           );
           true ;\
         } &&\
-	npm run env &&\
+        npm config set unsafe-perm true
+        npm run env &&\
         npm i &&\
         SAUCE_USERNAME=${SAUCE_USERNAME} \
         SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} \


### PR DESCRIPTION
This fixes an issue with npm which cowardly refuses to build
in working directories that don\'t match the name of the
package. See this piece of code:

https://github.com/npm/npm/blob/94929cf05854886b1aa9b611ad3bbb6dbbb575f3/lib/utils/lifecycle.js#L54-L62'