### PR TITLE
fix(build): ignore semantic-release errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pages": "echo stub for build.sh",
     "prepublish": "babel src -d lib",
     "postpublish": "npm run access",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "semantic-release": "semantic-release pre || exit 0; npm publish && semantic-release post",
     "test": "npm run lint",
     "watch": "npm run prepublish -- -w"
   },

--- a/src/provision-stylelint-config-strict.js
+++ b/src/provision-stylelint-config-strict.js
@@ -34,6 +34,7 @@ export function provisionEslintConfigStrict() {
           pretest: 'npm run lint',
           lint: 'npm-run-all --parallel lint:*',
           'lint:css': 'stylelint $npm_package_config_lint_css_options $npm_package_directories_src/*.css',
+          'semantic-release': 'semantic-release pre || exit 0; npm publish && semantic-release post',
         },
       }, packageJson))),
     },


### PR DESCRIPTION
semantic-release will exit with non-zero exit codes if there is no new
version to release, as such, any `chore`/`style`/`doc` only commits will
fail the build. This change makes it so that the exit code semantic
release emits is ignored, and the build will pass, even if it fails.