### PR TITLE
fix: doc:css script running on lib when it should be src

### DIFF
--- a/src/provision-docgen.js
+++ b/src/provision-docgen.js
@@ -65,8 +65,8 @@ function addDocCss(packageJson) {
       'doc:css': [
         'postcss',
         '$npm_package_config_doc_css_options',
-        '$npm_package_examplestyle',
         '-o $npm_package_directories_site/bundle.css',
+        '$npm_package_directories_src/example.css',
       ].join(' '),
       'watch:doc:css': 'npm run doc:css -- --watch',
     },


### PR DESCRIPTION
Also according to postcss-cli docs it should be `postcss [options] -o output/file.css input/file.css` so switch order to reflect.