### PR TITLE
fix(build): switch to node:argon-slim docker image

### DIFF
--- a/assets/build.sh
+++ b/assets/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SSH_KEY="${1:-/root/.ssh/id_rsa}"
-DOCKER_IMAGE="docker.io/economist/base-node:latest"
+DOCKER_IMAGE="node:argon-slim"
 HOST_IP=$(ip route get 1 | awk '{print $NF;exit}')
 WITH_SINOPIA=${WITH_SINOPIA:-"true"}
 SINOPIA_URL="http://${HOST_IP}:4873"


### PR DESCRIPTION
This change seems impactful, but it's not really.
Traditionally, components using the old devpack were using `economistprod/node4-base` ([see here](
https://github.com/EconomistDigitalSolutions/fe-component-devpack/blob/master/build.sh#L4)).
This is an old, no longer maintained image. During the development of provision-react it was
decided to migrate to the official fe-blogs image, however, the differences between the two are
very large, as `economistprod/node4-base` is Debian based and the fe-blogs image is Alpine based.

This effectively reverts the switch to the fe-blogs image, back to a Debian based build container.
It is important we do this because Alpine uses lib musl as its core std lib, and our test tooling -
specifically sauceconnect (part of our Karma suite) relies on glibc (the most common std lib, one
that comes with Debian). Alpine doesn't ship with glibc, and glibc is not installable, and because
we need glibc for testing, we cannot use Alpine.

`node:argon-slim` is the smallest, officially supported (by Node) image. It is Debian based.