### PR TITLE
fix(build): use node:argon over node:argon-slim

### DIFF
--- a/assets/build.sh
+++ b/assets/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SSH_KEY="${1:-/root/.ssh/id_rsa}"
-DOCKER_IMAGE="node:argon-slim"
+DOCKER_IMAGE="node:argon"
 HOST_IP=$(ip route get 1 | awk '{print $NF;exit}')
 WITH_SINOPIA=${WITH_SINOPIA:-"true"}
 SINOPIA_URL="http://${HOST_IP}:4873"
@@ -35,7 +35,6 @@ exec docker run \
     "${DOCKER_IMAGE}" \
     /bin/sh -cx "\
         trap 'chmod 777 node_modules -R' EXIT &&\
-        apt-get update && apt-get install git -y
         cd /code &&\
         umask 000 &&\
         printf \"@economist:registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=%s\n\" \"$NPM_TOKEN\" > ~/.npmrc &&\


### PR DESCRIPTION
node:argon-slim is missing too many tools to build the test environment needed for our components.

It is missing git (required by build), python (used for node-gyp, required by devdeps), and will not successfully install phantomjs (required in our karma setup). node:argon has all of these.

Drawing this to @fabiosantoscode's attention has they originally objected to using `node:argon` over `node:argon-slim`.