### PR TITLE
fix(provision-mainfiles): import babel-polyfill in example template

### DIFF
--- a/src/provision-mainfiles.js
+++ b/src/provision-mainfiles.js
@@ -75,7 +75,8 @@ if (process.env.NODE_ENV !== 'production') {
     'src/example.js': {
       questions: [ nameQuestion() ],
       contents: (contents, answers) => (contents ||
-`import React from 'react';
+`import 'babel-polyfill';
+import React from 'react';
 import ${ packageToClass(answers) } from './';
 
 export default (


### PR DESCRIPTION
This adds the babel-polyfill to the example.js, just in case any non-polyfilled code is used within the example.