### PR TITLE
feat: Do some retries on NPM

### DIFF
--- a/assets/build.sh
+++ b/assets/build.sh
@@ -49,7 +49,7 @@ exec docker run \
         } &&\
         npm config set unsafe-perm true &&\
         npm run env &&\
-        npm i &&\
+        (npm i || npm i || (npm config delete registry && npm i)) &&\
         SAUCE_USERNAME=${SAUCE_USERNAME} \
         SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} \
         npm t &&\


### PR DESCRIPTION
This tries to install against sinopia twice, then flips the table and uses the real registry.

This means that we get the speed of a cached sinopia-driven install, but if that fails then we can have a slow one.