### PR TITLE
fix: set the @semantic-release registry to registry.npmjs.com

### DIFF
--- a/assets/build.sh
+++ b/assets/build.sh
@@ -37,7 +37,7 @@ exec docker run \
         trap 'chmod 777 node_modules -R' EXIT &&\
         cd /code &&\
         umask 000 &&\
-        printf \"@economist:registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=%s\n\" \"$NPM_TOKEN\" > ~/.npmrc &&\
+        printf \"@semantic-release:registry=https://registry.npmjs.org/\n@economist:registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=%s\n\" \"$NPM_TOKEN\" > ~/.npmrc &&\
         { \
           [ \"$WITH_SINOPIA\" != \"true\" ] || \
           (


### PR DESCRIPTION
This makes our builds avoid using sinopia for the `@semantic-release` repository.