### PR TITLE
Legacy removal fixes

### DIFF
--- a/src/provision-legacy-removal.js
+++ b/src/provision-legacy-removal.js
@@ -55,13 +55,13 @@ export function provisionLegacyRemoval() {
           Reflect.deleteProperty(packageJson.config, 'testbundle_opts');
           Reflect.deleteProperty(packageJson.config, 'ghpages_files');
         }
-        packageJson.files = without(packageJson.files || [], [
+        packageJson.files = without(packageJson.files || [],
           '*.js',
           '*.es6',
           '*.css',
           '!karma.conf.js',
           '!testbundle.js',
-        ]);
+        );
         const build = getObjectPath(packageJson, 'scripts.build');
         if (build && build !== 'npm-run-all --parallel build:*' && build !== 'npm-assets .') {
           Reflect.deleteProperty(packageJson.scripts, 'build');

--- a/src/provision-legacy-removal.js
+++ b/src/provision-legacy-removal.js
@@ -12,6 +12,9 @@ export function provisionLegacyRemoval() {
       contents: jsonFile((packageJson) => {
         Reflect.deleteProperty(packageJson, 'component-devserver');
         Reflect.deleteProperty(packageJson, 'devpack-doc');
+        if (packageJson['pre-commit']) {
+          Reflect.deleteProperty(packageJson, 'pre-commit');
+        }
         if (packageJson.scripts) {
           Reflect.deleteProperty(packageJson.scripts, 'preinstall');
           Reflect.deleteProperty(packageJson.scripts, 'postinstall');
@@ -35,6 +38,17 @@ export function provisionLegacyRemoval() {
           Reflect.deleteProperty(packageJson.devDependencies, 'react');
           Reflect.deleteProperty(packageJson.devDependencies, 'chai-things');
           Reflect.deleteProperty(packageJson.devDependencies, 'cssnext');
+          Reflect.deleteProperty(packageJson.devDependencies, 'babel-runtime');
+          Reflect.deleteProperty(packageJson.devDependencies, 'babel-loader');
+          Reflect.deleteProperty(packageJson.devDependencies, 'browser-sync');
+          Reflect.deleteProperty(packageJson.devDependencies, 'karma-chai');
+          Reflect.deleteProperty(packageJson.devDependencies, 'karma-chrome-launcher');
+          Reflect.deleteProperty(packageJson.devDependencies, 'pre-commit');
+          Reflect.deleteProperty(packageJson.devDependencies, 'react-addons-test-utils');
+          Reflect.deleteProperty(packageJson.devDependencies, 'react-dom');
+        }
+        if (packageJson.dependencies) {
+          Reflect.deleteProperty(packageJson.dependencies, 'babel-runtime');
         }
         if (packageJson.config) {
           Reflect.deleteProperty(packageJson.config, 'lint_opts');


### PR DESCRIPTION
I noticed that we have a few more dangling dependencies - so part of this PR removes them while provisioning - as part of the `provision-legacy-removal` script.

This PR also removes the `pre-commit` package.json config, as we're now using `ghooks`. This has caused some conflicts before as having the two of them doesn't work so well. I think @gcedo experienced this issue before a few times. This should fix that now :smile: 

Lastly, I was using `lodash.without` wrong, and so I've fixed that so that it actually removes file references from package.json