### PR TITLE
Drop babel runtime

### DIFF
--- a/package-versions.json
+++ b/package-versions.json
@@ -20,7 +20,7 @@
   "mocha": "^2.4.5",
   "npm-assets": "^0.1.1",
   "npm-run-all": "^1.5.1",
-  "phantomjs-prebuilt": "^2.1.4",
+  "phantomjs-prebuilt": "^2.1.5",
   "postcss-cli": "^2.5.1",
   "postcss-cssnext": "^2.4.0",
   "postcss-import": "^8.0.2",

--- a/src/provision-legacy-removal.js
+++ b/src/provision-legacy-removal.js
@@ -55,6 +55,12 @@ export function provisionLegacyRemoval() {
           Reflect.deleteProperty(packageJson.config, 'testbundle_opts');
           Reflect.deleteProperty(packageJson.config, 'ghpages_files');
         }
+        if (packageJson.babel && packageJson.babel.optional) {
+          packageJson.babel.optional = without(packageJson.babel.optional, 'runtime');
+          if (packageJson.babel.optional.length === 0) {
+            Reflect.deleteProperty(packageJson.babel, 'optional');
+          }
+        }
         packageJson.files = without(packageJson.files || [],
           '*.js',
           '*.es6',


### PR DESCRIPTION
We have already from babel-runtime to polyfill (#40) - but some reprovisioned
components have been left with the runtime option. This commit removes the
runtime option if present, ensuring that the polyfill is the only thing used