### PR TITLE
fix(build): remove registry config post-install

### DIFF
--- a/assets/build.sh
+++ b/assets/build.sh
@@ -50,6 +50,9 @@ exec docker run \
         npm config set unsafe-perm true &&\
         npm run env &&\
         (npm i || npm i || (npm config delete registry && npm i)) &&\
+        npm config delete registry &&\
+        npm config delete @semantic-release:registry &&\
+        npm config delete @economist:registry &&\
         SAUCE_USERNAME=${SAUCE_USERNAME} \
         SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} \
         npm t &&\


### PR DESCRIPTION
Sinopia seems to mess with npm publish settings. This change removes the sinopia
registry settings after install - so that it is not used come publish time. We
only use sinopia to cache npm dependencies, so this should not impact the build
(except for fixing sinopia publish breakages)