### PR TITLE
fix: ensure tests import code from `src` not `lib`

### DIFF
--- a/src/provision-react-testsuite.js
+++ b/src/provision-react-testsuite.js
@@ -66,7 +66,7 @@ export function provisionTestFiles() {
       questions: [ nameQuestion() ],
       contents: (contents, answers) => contents || `
 import 'babel-polyfill';
-import ${ packageToClass(answers) } from '..';
+import ${ packageToClass(answers) } from '../src';
 import chai from 'chai';
 import React from 'react/addons';
 const TestUtils = React.addons.TestUtils;


### PR DESCRIPTION
The tests need to import from src, to make the watch process more reliable.