### PR TITLE
fix: prefixed classname with . rendered.find()

### DIFF
--- a/src/provision-react-testsuite.js
+++ b/src/provision-react-testsuite.js
@@ -89,7 +89,7 @@ describe('${ packageToClass(answers) }', () => {
     let ${ packageToCamel(answers) } = null;
     beforeEach(() => {
       rendered = mount(<${ packageToClass(answers) } />);
-      ${ packageToCamel(answers) } = rendered.find('${ packageToCss(answers) }');
+      ${ packageToCamel(answers) } = rendered.find('.${ packageToCss(answers) }');
     });
 
     it('renders a top level div.${ packageToCss(answers) }', () => {


### PR DESCRIPTION
Enables the element to be correctly found.