### PR TITLE
chore: switch eslint pin to semver major (^)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-stage-2": "^6.5.0",
-    "eslint": "~2.5.3",
+    "eslint": "^2.5.3",
     "eslint-config-strict": "^8.5.0",
     "eslint-plugin-filenames": "^0.2.0",
     "ghooks": "^1.0.1",


### PR DESCRIPTION
We pinned this because of babel-eslint and es-traverse failing, but it does not any more. Lets switch back.