### PR TITLE
fix(karma): ensure we test on a modern Safari

### DIFF
--- a/assets/karma.conf.js
+++ b/assets/karma.conf.js
@@ -27,6 +27,7 @@ module.exports = function configureKarma(config) {
     SauceSafariLatest: {
       base: 'SauceLabs',
       browserName: 'Safari',
+      platform: 'Mac 10.9',
     },
     SauceInternetExplorerLatest: {
       base: 'SauceLabs',


### PR DESCRIPTION
If we don't specify the platform, SauceLabs has a tendency to prefer Windows, and
so we are testing Safari 5 on windows, which was discontinued in 2012. This change
specifies a modern OSX platform, which will make it use a modern safari (Safari 7).

Safari 7/Mavericks was chosen as it is the oldest OSX with > 10% adoption, according
to https://www.gosquared.com/global/mac/el-capitan/#launch