### PR TITLE
fix: remove legacy gitignore lines

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ git['.git/config'].questions[gitRepositoryQuestionIndex].default = (answers, dir
 );
 export function provisionReactComponent() {
   return combineProvisionerSets(
+    provisionLegacyRemoval(),
     provisionEditorConfig(),
     git,
     provisionGitIgnore({
@@ -56,7 +57,6 @@ export function provisionReactComponent() {
       scriptName: 'lint:js',
     }),
     provisionGocdFe(),
-    provisionLegacyRemoval(),
     provisionMainFiles(),
     provisionPackageJson(),
     provisionReactTestSuite(),

--- a/src/provision-legacy-removal.js
+++ b/src/provision-legacy-removal.js
@@ -1,12 +1,25 @@
 #!/usr/bin/env node
 import getObjectPath from 'lodash.get';
 import jsonFile from 'packagesmith.formats.json';
+import multilineFile from 'packagesmith.formats.multiline';
 import { runProvisionerSet } from 'packagesmith';
 import sortPackageJson from 'sort-package-json';
 import without from 'lodash.without';
 
 export function provisionLegacyRemoval() {
   return {
+
+    '.gitignore': {
+      contents: multilineFile((contents) => without(contents || [],
+        'node_modules/',
+        '*.log',
+        '*.js',
+        'bundle.css',
+        '*.html',
+        '!karma.conf.js',
+        'testbundle.js',
+      )),
+    },
 
     'package.json': {
       after: 'npm prune',


### PR DESCRIPTION
This change removes lines that are potentially already existing in old components we have.
These old lines cause lots of problems because they're incompatible with the new version -
such as `*.js`.