### PR TITLE
fix(travis): fix broken deployments by ensuring GH_TOKEN repo url

### DIFF
--- a/src/provision-travis.js
+++ b/src/provision-travis.js
@@ -1,13 +1,28 @@
 #!/usr/bin/env node
+import { format as formatUrl, parse as parseUrl } from 'url';
 import defaultsDeep from 'lodash.defaultsdeep';
 import jsonFile from 'packagesmith.formats.json';
+import repositoryQuestion from 'packagesmith.questions.repository';
 import { runProvisionerSet } from 'packagesmith';
 import sortPackageJson from 'sort-package-json';
 import yamlFile from 'packagesmith.formats.yaml';
+function getAuthenticatedUrl(url) {
+  let parsed = parseUrl(String(url));
+  if (parsed.protocol === null) {
+    parsed = parseUrl(`https://${ String(url) }`);
+    if (/^\/:/.test(parsed.pathname)) {
+      parsed.pathname = parsed.pathname.replace(/^\/:/, '/');
+    }
+  }
+  parsed.protocol = 'https';
+  parsed.auth = 'GH_TOKEN';
+  return formatUrl(parsed).replace('GH_TOKEN', '${GH_TOKEN}');
+}
 export function provisionTravisYaml() {
   return {
     '.travis.yml': {
-      contents: yamlFile((travisYaml) => defaultsDeep({
+      questions: [ repositoryQuestion() ],
+      contents: yamlFile((travisYaml, { repository }) => defaultsDeep({
         /* eslint-disable camelcase, id-match */
         sudo: false,
         language: 'node_js',
@@ -20,7 +35,11 @@ export function provisionTravisYaml() {
           '4',
           'stable',
         ],
-        after_success: 'travis-after-all && npm run pages && npm run semantic-release',
+        after_success: [
+          'travis-after-all',
+          'npm run semantic-release',
+          `npm run pages -- --repo ${ getAuthenticatedUrl(repository) }`,
+        ].join(' && '),
         /* eslint-enable camelcase, id-match */
       }, travisYaml)),
     },


### PR DESCRIPTION
This fixes the broken travis deployment scripts - which would always fail because npm run pages
would deploy to an http url which it had no access to. This specifies the repository option which
includes a GH_TOKEN so that travis can push. It also reorders the script to ensure semantic-release
is always run first, as this is the higher priority of the two publish scripts