### PR TITLE
fix(docgen): move browserify transform into command line flags

### DIFF
--- a/src/provision-docgen.js
+++ b/src/provision-docgen.js
@@ -115,6 +115,7 @@ function addDocJs(packageJson) {
         js: { // eslint-disable-line id-length
           options: [
             '-d',
+            '-t babelify',
             '-x react/lib/ReactContext',
             '-x react/lib/ExecutionEnvironment',
             '-r react',

--- a/src/provision-legacy-removal.js
+++ b/src/provision-legacy-removal.js
@@ -34,6 +34,7 @@ export function provisionLegacyRemoval() {
         Reflect.deleteProperty(packageJson, 'pre-commit');
         Reflect.deleteProperty(packageJson, 'watch');
         Reflect.deleteProperty(packageJson, 'babel');
+        Reflect.deleteProperty(packageJson, 'browserify');
         if (packageJson.scripts) {
           Reflect.deleteProperty(packageJson.scripts, 'preinstall');
           Reflect.deleteProperty(packageJson.scripts, 'postinstall');


### PR DESCRIPTION
The browserify.transform field is read by upstream dependencies during the browserify compilation phase, which was highlighted
due to the babel 5-6 transition. We already compile down the ES6 code into ES5 code during the prepublish step, so at-best the
browserify transform field is slowing down our upstream builds, and at worst it is breaking them.

This commit removes the browserify.transform field, in favour of adding `-t babelify` to the doc build step - which is the only
place that makes use of browserify in these builds. This means upstream builds just pull in plain lib/index and do not pass it
through any transforms